### PR TITLE
fix: Limit min zoom level

### DIFF
--- a/src/features/map/presentation/components/tourenbuddy-map.vue
+++ b/src/features/map/presentation/components/tourenbuddy-map.vue
@@ -44,6 +44,8 @@ onMounted(() => {
     style: SWISSTOPO_STYLES[0]!.style,
     center: [8.2, 46.8],
     zoom: 8,
+    minZoom: 5.8,
+    renderWorldCopies: false,
   })
 
   map.value = mapInstance


### PR DESCRIPTION
## 📝 Description

We only display the swisstopo vector tiles. minZoom 5.8 shows all of Switzerland on most devices. See screenshots below for fully zoomed out maps on desktop/mobile.

## 📸 Screenshots / Demo


<img width="1512" height="982" alt="Screenshot 2026-05-09 at 16 40 33" src="https://github.com/user-attachments/assets/d1a3d989-52e6-44dd-8125-dcb0a44ae543" />
<img width="1512" height="982" alt="Screenshot 2026-05-09 at 16 40 06" src="https://github.com/user-attachments/assets/ba1b6e44-fccb-49bc-929d-5387ef9266fe" />

---

_By submitting this PR, I agree to follow the project's code of conduct and contribution guidelines._
